### PR TITLE
Tambahkan Module response dan perbaiki script untuk membaca modules.list

### DIFF
--- a/supporting_files/docker-entrypoint.sh
+++ b/supporting_files/docker-entrypoint.sh
@@ -16,7 +16,9 @@ cat /usr/local/etc/php-fpm.d/www.conf
 webcorecli project $PROJECT
 webcorecli config $PROJECT
 webcorecli theme $PROJECT dore
-while read -r name url; do
+
+# tambahkan `|| [[ -n $name ]]` agar membaca baris terakhir dari modules.list, tanpa itu baris terkahir tidak akan terbaca jika file tidak diahiri dengan baris kosong
+while read -r name url || [[ -n $name ]]; do
   # Lewati baris kosong atau baris yang diawali dengan #
   [[ -z "$name" || "$url" =~ ^# ]] && continue
   echo "webcorecli module $PROJECT $name $url"

--- a/supporting_files/docker-entrypoint.sh
+++ b/supporting_files/docker-entrypoint.sh
@@ -23,7 +23,7 @@ while read -r name url || [[ -n $name ]]; do
   [[ -z "$name" || "$url" =~ ^# ]] && continue
   echo "webcorecli module $PROJECT $name $url"
   webcorecli module "$PROJECT" "$name" "$url"
-done < "/etc/$PROJECT/modules.list"
+done < <(grep -v '^[[:space:]]*$' "/etc/$PROJECT/modules.list")
 
 # Perbaiki config sesuai DOMAIN
 confdir=$APPDIR/$PROJECT/application/config/domains

--- a/supporting_files/modules.list
+++ b/supporting_files/modules.list
@@ -9,5 +9,4 @@ mpdne https://gitlab.com/webcore2/module-mpdn-eksternal.git
 komdat https://gitlab.com/webcore2/module-mpdn-komdat.git
 dhis https://gitlab.com/webcore2/module-mpdn-dhis2.git
 fhir https://gitlab.com/webcore2/module-mpdn-fhir.git
-mpdne https://gitlab.com/webcore2/module-mpdn-eksternal.git
 response https://gitlab.com/webcore2/module-mpdn-response.git

--- a/supporting_files/modules.list
+++ b/supporting_files/modules.list
@@ -9,3 +9,5 @@ mpdne https://gitlab.com/webcore2/module-mpdn-eksternal.git
 komdat https://gitlab.com/webcore2/module-mpdn-komdat.git
 dhis https://gitlab.com/webcore2/module-mpdn-dhis2.git
 fhir https://gitlab.com/webcore2/module-mpdn-fhir.git
+mpdne https://gitlab.com/webcore2/module-mpdn-eksternal.git
+response https://gitlab.com/webcore2/module-mpdn-response.git


### PR DESCRIPTION
Sebelumnya, ketika menambahkan module response di `modules.list di baris terkahir dan tidak diahiri dengan baris kosong, baris tersebut dilewati sehingga perintah `webcorecli module mpdn response` tidak dijalankan